### PR TITLE
"prefix" is not enough for sass showcasing, added "names"

### DIFF
--- a/sass-showcases/src/SassShowcases.js
+++ b/sass-showcases/src/SassShowcases.js
@@ -6,8 +6,13 @@ import { getTransitionsHtml } from './transition-helper';
 
 export class SassShowcases extends HTMLElement {
   connectedCallback() {
-    const prefix = this.getAttribute('css-props-prefix');
-    const props = getCssCustomProps(prefix);
+    const prefix = this.getAttribute('css-props-prefix') || '';
+
+    const names = new Set(
+      (this.getAttribute('css-props-names') || '').split(',')
+    );
+
+    const props = getCssCustomProps(prefix, names);
 
     const styleKey = this.getAttribute('style-key');
     const componentType = this.getAttribute('component-type') || 'box';
@@ -22,7 +27,7 @@ export class SassShowcases extends HTMLElement {
       return;
     }
 
-    if (prefix.includes('spacing')) {
+    if (prefix.includes('spacing') && !prefix.includes('letter-spacing')) {
       this.innerHTML = getScaleHtml(props);
       return;
     }

--- a/sass-showcases/src/css-props.js
+++ b/sass-showcases/src/css-props.js
@@ -30,5 +30,8 @@ const getAllCSSCustomProps = () => {
   return uniqBy(allProps, ([name]) => name);
 };
 
-export const getCssCustomProps = (prefix = '') =>
-  getAllCSSCustomProps().filter(([name]) => name.startsWith(prefix));
+export const getCssCustomProps = (prefix = '', names = new Set()) =>
+  getAllCSSCustomProps().filter(([name]) => {
+    if (prefix) return name.startsWith(prefix);
+    return names.has(name);
+  });

--- a/sass-showcases/src/transition-helper.js
+++ b/sass-showcases/src/transition-helper.js
@@ -6,7 +6,6 @@ export const getTransitionsHtml = (props) => {
 
     boxes.forEach((box) =>
       box.addEventListener('click', () => {
-        console.log('!!!! clicked');
         if (box.className.includes('clicked'))
           box.className = box.className.replace(' clicked', '');
         else box.className = `${box.className} clicked`;

--- a/sass-showcases/stories/sass-showcases.stories.js
+++ b/sass-showcases/stories/sass-showcases.stories.js
@@ -3,8 +3,14 @@ import './sass-showcases.css';
 import './tokens.scss';
 import { html } from 'lit-html';
 
-export const background_color = () => html`<dockit-sass-showcases
+export const background_color_by_prefix = () => html`<dockit-sass-showcases
   css-props-prefix="--color"
+  component-class="box"
+  style-key="background-color"
+></dockit-sass-showcases>`;
+
+export const background_color_by_names = () => html`<dockit-sass-showcases
+  css-props-names="--color-white,--color-primary,--color-gray-300,--color-focus-outline"
   component-class="box"
   style-key="background-color"
 ></dockit-sass-showcases>`;
@@ -32,6 +38,12 @@ export const shadow = () => html`<dockit-sass-showcases
 
 export const spacing = () => html`<dockit-sass-showcases
   css-props-prefix="--spacing"
+></dockit-sass-showcases>`;
+
+export const letter_spacing = () => html`<dockit-sass-showcases
+  css-props-prefix="--letter-spacing"
+  component-type="text"
+  style-key="letter-spacing"
 ></dockit-sass-showcases>`;
 
 export const line_height = () => html`<dockit-sass-showcases

--- a/sass-showcases/stories/tokens.scss
+++ b/sass-showcases/stories/tokens.scss
@@ -45,7 +45,7 @@
   --line-height-normal: 1.8;
   --line-height-loose: 2.2;
 
-  --letter-spacing-dense: -0.015em;
+  --letter-spacing-dense: -0.075em;
   --letter-spacing-normal: normal;
   --letter-spacing-loose: 0.075em;
 
@@ -69,9 +69,4 @@
     'Segoe UI Symbol';
   --font-family-serif: Georgia, 'Times New Roman', serif;
   --font-family-mono: Menlo, Monaco, 'Courier New', monospace;
-
-  --color-white: #ffffff;
-  --color-primary: #3082ce;
-  --color-gray-300: #cbd5e0;
-  --color-focus-outline: #4299e14c;
 }


### PR DESCRIPTION
Sass showcasing component accepts a "prefix" to identify which css variables to showcase.
This is not enough to differentiate between `--font-sans` and `--font-weight-bold` for example, as `prefix='--font'` will also showcase the font-weight variables, and this is not correct.
To fix this the `names` attribute was added and can be used as an alternative to `prefix`: it takes a list of css variable names and showcases them.

Can be seen in action here:
https://backlight.dev/edit/4BeMe20hqOWTkdUL2NuJ/sass-showcases/stories/sass-showcases.stories.js?branch=showcase-sass-short-caption@tLlGPKdxk2VRYywCKUXNaV8PFt62