### PR TITLE
chore: remove unused dependency dark-theme-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "copy-to-clipboard": "^3.3.1",
-    "dark-theme-utils": "^0.4.0",
     "deepmerge": "^4.2.2",
     "is-plain-object": "^5.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Sadly, but it's not used anymore anywhere, I forgot to remove it earlier.

Good to mention why for the code history: it's been used before the introduction of the `@tailwindcss/typography`, but that one has certain requirements for how the dark mode is switched, and `dark-theme-utils` didn't fit it. Also I started using StencilJS to remove Lit dependency and prevent all kind of migration issues for `mdjs-layout` users, and `dark-theme-utils` didn't work for StencilJS either. So it was logical to remove it for now.