### PR TITLE
Css showcases modes

### DIFF
--- a/css-showcases/src/CssShowcases.js
+++ b/css-showcases/src/CssShowcases.js
@@ -18,8 +18,28 @@ export class CssShowcases extends HTMLElement {
     const styleKey = this.getAttribute('style-key');
     const componentType = this.getAttribute('component-type') || 'box';
 
-    if (prefix.includes('transition') || mode === 'transition') {
-      this.innerHTML = getTransitionsHtml(props);
+    if (
+      prefix.includes('transition') ||
+      prefix.includes('time') ||
+      prefix.includes('ease') ||
+      prefix.includes('animation') ||
+      mode === 'time' ||
+      mode === 'ease' ||
+      mode === 'animation'
+    ) {
+      let _mode =
+        mode != '' && mode != 'transition'
+          ? mode
+          : prefix.includes('time') ||
+            prefix.includes('transition') ||
+            mode === 'transition'
+          ? 'time'
+          : prefix.includes('ease')
+          ? 'ease'
+          : prefix.includes('animation')
+          ? 'animation'
+          : null;
+      this.innerHTML = getTransitionsHtml(props, _mode);
       return;
     }
 

--- a/css-showcases/src/CssShowcases.js
+++ b/css-showcases/src/CssShowcases.js
@@ -3,6 +3,7 @@ import { getCssCustomProps } from './css-props';
 import { getZIndexHtml } from './z-index-helper';
 import { getScaleHtml } from './space-helper';
 import { getTransitionsHtml } from './transition-helper';
+import styles from './alerts.module.scss';
 
 export class CssShowcases extends HTMLElement {
   connectedCallback() {
@@ -28,18 +29,25 @@ export class CssShowcases extends HTMLElement {
       mode === 'animation'
     ) {
       let _mode =
-        mode != '' && mode != 'transition'
+        mode != ''
           ? mode
-          : prefix.includes('time') ||
-            prefix.includes('transition') ||
-            mode === 'transition'
+          : prefix.includes('time') || prefix.includes('transition')
           ? 'time'
           : prefix.includes('ease')
           ? 'ease'
           : prefix.includes('animation')
           ? 'animation'
           : null;
-      this.innerHTML = getTransitionsHtml(props, _mode);
+      this.innerHTML = getTransitionsHtml(
+        props,
+        _mode,
+        prefix.includes('transition')
+      );
+      if (prefix.includes('transition'))
+        this.innerHTML =
+          this.innerHTML +
+          /*html*/
+          `<p class="${styles.warn}"><code>--transition</code> CSS Custom Props prefix is deprecated.<br>Use <code>--time</code> prefix instead, or use <code>&lt;dockit-css-showcases mode="time" css-props-prefix="--transition"/></code> elements to explicitely set the rendering mode.</p>`;
       return;
     }
 
@@ -64,6 +72,7 @@ export class CssShowcases extends HTMLElement {
       .join(' ');
 
     this.innerHTML =
+      this.warningHTML +
       this.innerHTML +
       /*html*/
       `<dockit-showcases

--- a/css-showcases/src/CssShowcases.js
+++ b/css-showcases/src/CssShowcases.js
@@ -7,6 +7,7 @@ import { getTransitionsHtml } from './transition-helper';
 export class CssShowcases extends HTMLElement {
   connectedCallback() {
     const prefix = this.getAttribute('css-props-prefix') || '';
+    const mode = this.getAttribute('mode') || '';
 
     const names = new Set(
       (this.getAttribute('css-props-names') || '').split(',')
@@ -17,17 +18,20 @@ export class CssShowcases extends HTMLElement {
     const styleKey = this.getAttribute('style-key');
     const componentType = this.getAttribute('component-type') || 'box';
 
-    if (prefix.includes('transition')) {
+    if (prefix.includes('transition') || mode === 'transition') {
       this.innerHTML = getTransitionsHtml(props);
       return;
     }
 
-    if (prefix.includes('z-index')) {
+    if (prefix.includes('z-index') || mode === 'z-index') {
       this.innerHTML = getZIndexHtml(props);
       return;
     }
 
-    if (prefix.includes('spacing') && !prefix.includes('letter-spacing')) {
+    if (
+      (prefix.includes('spacing') && !prefix.includes('letter-spacing')) ||
+      mode === 'scale'
+    ) {
       this.innerHTML = getScaleHtml(props);
       return;
     }

--- a/css-showcases/src/alerts.module.scss
+++ b/css-showcases/src/alerts.module.scss
@@ -1,0 +1,16 @@
+.warn {
+  background-color: orange;
+  border-color: darken(orange, 10);
+  border-width: 2px;
+  border-radius: 0.375rem;
+  border-style: solid;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  padding: 0.75rem 0.55rem;
+
+  code {
+    background-color: rgba(0, 0, 0, 0.1);
+    padding: 0.15rem 0.25rem;
+    border-radius: 0.275rem;
+  }
+}

--- a/css-showcases/src/transition-box.module.scss
+++ b/css-showcases/src/transition-box.module.scss
@@ -4,6 +4,10 @@
   color: #fff;
 }
 
+.details-sm {
+  font-size: 0.55rem;
+}
+
 .wrapper {
   display: flex;
   flex-direction: column;

--- a/css-showcases/src/transition-helper.js
+++ b/css-showcases/src/transition-helper.js
@@ -1,14 +1,34 @@
 import styles from './transition-box.module.scss';
 
-export const getTransitionsHtml = (props) => {
+export const getTransitionsHtml = (props, mode) => {
+  function style(name) {
+    let rules = [];
+    if (mode === 'animation') {
+      rules.push(`animation: var(${name}) forwards`);
+    } else {
+      rules.push('transition-delay: 0');
+      rules.push(
+        `transition-duration: ${mode === 'time' ? `var(${name})` : '1s'}`
+      );
+      rules.push('transition-property: margin-left');
+      rules.push(
+        `transition-timing-function: ${
+          mode === 'ease' ? `var(${name})` : 'linear'
+        }`
+      );
+    }
+
+    return rules.join(';');
+  }
+
   setTimeout(() => {
     const boxes = document.querySelectorAll('.transitionBox');
-
+    const toggle = mode === 'animation' ? 'no-anim' : 'clicked';
     boxes.forEach((box) =>
       box.addEventListener('click', () => {
-        if (box.className.includes('clicked'))
-          box.className = box.className.replace(' clicked', '');
-        else box.className = `${box.className} clicked`;
+        if (box.className.includes(toggle))
+          box.className = box.className.replace(` ${toggle}`, '');
+        else box.className = `${box.className} ${toggle}`;
       })
     );
   }, 300);
@@ -17,16 +37,19 @@ export const getTransitionsHtml = (props) => {
 <div class="${styles.wrapper}">
   <style>
     .clicked { margin-left: 20rem; }
+    .no-anim { animation: none !important; }
   </style>
   ${props
     .map(
       ([name, value], i) => /*html*/ `
       <div id="transitionBox${i}"
-          class="${styles.box} transitionBox"
-          style="transition: all var(${name}) ease 0s;"
+          class="${styles.box} ${
+        mode === 'animation' ? 'no-anim' : ''
+      } transitionBox"
+          style="${style(name)}"
       >
         <code class="${styles.details}">${name}</code>
-        <code class="${styles.details}">${value}</code>
+        <code class="${styles.details} ${styles['details-sm']}">${value}</code>
       </div>`
     )
     .join('\n')}

--- a/css-showcases/stories/css-showcases.stories.js
+++ b/css-showcases/stories/css-showcases.stories.js
@@ -33,6 +33,14 @@ export const mode_transition = () => html`<dockit-css-showcases
   mode="transition"
 ></dockit-css-showcases>`;
 
+export const easing = () => html`<dockit-css-showcases
+  css-props-prefix="--ease"
+></dockit-css-showcases>`;
+
+export const animation = () => html`<dockit-css-showcases
+  css-props-prefix="--animation"
+></dockit-css-showcases>`;
+
 export const border_radius = () => html`<dockit-css-showcases
   css-props-prefix="--border-radius"
   component-class="box wide"

--- a/css-showcases/stories/css-showcases.stories.js
+++ b/css-showcases/stories/css-showcases.stories.js
@@ -24,13 +24,17 @@ export const mode_z_index = () => html`<dockit-css-showcases
   mode="z-index"
 ></dockit-css-showcases>`;
 
-export const transition = () => html`<dockit-css-showcases
-  css-props-prefix="--transition"
+export const time = () => html`<dockit-css-showcases
+  css-props-prefix="--time"
 ></dockit-css-showcases>`;
 
-export const mode_transition = () => html`<dockit-css-showcases
-  css-props-prefix="--time"
-  mode="transition"
+export const mode_time = () => html`<dockit-css-showcases
+  css-props-prefix="--duration"
+  mode="time"
+></dockit-css-showcases>`;
+
+export const transition_deprecated = () => html`<dockit-css-showcases
+  css-props-prefix="--transition"
 ></dockit-css-showcases>`;
 
 export const easing = () => html`<dockit-css-showcases

--- a/css-showcases/stories/css-showcases.stories.js
+++ b/css-showcases/stories/css-showcases.stories.js
@@ -19,8 +19,18 @@ export const z_index = () => html`<dockit-css-showcases
   css-props-prefix="--z-index"
 ></dockit-css-showcases>`;
 
+export const mode_z_index = () => html`<dockit-css-showcases
+  css-props-prefix="--layer"
+  mode="z-index"
+></dockit-css-showcases>`;
+
 export const transition = () => html`<dockit-css-showcases
   css-props-prefix="--transition"
+></dockit-css-showcases>`;
+
+export const mode_transition = () => html`<dockit-css-showcases
+  css-props-prefix="--time"
+  mode="transition"
 ></dockit-css-showcases>`;
 
 export const border_radius = () => html`<dockit-css-showcases
@@ -38,6 +48,11 @@ export const shadow = () => html`<dockit-css-showcases
 
 export const spacing = () => html`<dockit-css-showcases
   css-props-prefix="--spacing"
+></dockit-css-showcases>`;
+
+export const mode_scale = () => html`<dockit-css-showcases
+  css-props-prefix="--sizes"
+  mode="scale"
 ></dockit-css-showcases>`;
 
 export const letter_spacing = () => html`<dockit-css-showcases

--- a/css-showcases/stories/tokens.scss
+++ b/css-showcases/stories/tokens.scss
@@ -23,6 +23,12 @@
   --time-fast: 150ms;
   --time-x-fast: 50ms;
 
+  --duration-x-slow: 1000ms;
+  --duration-slow: 500ms;
+  --duration-medium: 250ms;
+  --duration-fast: 150ms;
+  --duration-x-fast: 50ms;
+
   --ease: cubic-bezier(0.25, 0, 0.5, 1);
   --ease-in: cubic-bezier(0.25, 0, 1, 1);
   --ease-out: cubic-bezier(0, 0, 0.75, 1);

--- a/css-showcases/stories/tokens.scss
+++ b/css-showcases/stories/tokens.scss
@@ -5,11 +5,23 @@
   --z-index-toast: 950;
   --z-index-tooltip: 1000;
 
+  --layer-drawer: 700;
+  --layer-dialog: 800;
+  --layer-dropdown: 900;
+  --layer-toast: 950;
+  --layer-tooltip: 1000;
+
   --transition-x-slow: 1000ms;
   --transition-slow: 500ms;
   --transition-medium: 250ms;
   --transition-fast: 150ms;
   --transition-x-fast: 50ms;
+
+  --time-x-slow: 1000ms;
+  --time-slow: 500ms;
+  --time-medium: 250ms;
+  --time-fast: 150ms;
+  --time-x-fast: 50ms;
 
   --border-radius-small: 0.125rem;
   --border-radius-medium: 0.25rem;
@@ -40,6 +52,17 @@
   --spacing-xx-large: 2.25rem;
   --spacing-xxx-large: 3rem;
   --spacing-xxxx-large: 4.5rem;
+
+  --sizes-xxx-small: 0.125rem;
+  --sizes-xx-small: 0.25rem;
+  --sizes-x-small: 0.5rem;
+  --sizes-small: 0.75rem;
+  --sizes-medium: 1rem;
+  --sizes-large: 1.25rem;
+  --sizes-x-large: 1.75rem;
+  --sizes-xx-large: 2.25rem;
+  --sizes-xxx-large: 3rem;
+  --sizes-xxxx-large: 4.5rem;
 
   --line-height-dense: 1.4;
   --line-height-normal: 1.8;

--- a/css-showcases/stories/tokens.scss
+++ b/css-showcases/stories/tokens.scss
@@ -23,6 +23,66 @@
   --time-fast: 150ms;
   --time-x-fast: 50ms;
 
+  --ease: cubic-bezier(0.25, 0, 0.5, 1);
+  --ease-in: cubic-bezier(0.25, 0, 1, 1);
+  --ease-out: cubic-bezier(0, 0, 0.75, 1);
+  --ease-in-out: cubic-bezier(0.1, 0, 0.9, 1);
+  --ease-elastic: cubic-bezier(0.5, 0.75, 0.75, 1.25);
+  --ease-squish: cubic-bezier(0.5, -0.1, 0.1, 1.5);
+  --ease-step: steps(2);
+
+  --animation-spin: spin 2s linear infinite;
+  --animation-ping: ping 5s var(--ease-out) infinite;
+  --animation-blink: blink 1s var(--ease-out) infinite;
+  --animation-float: float 3s var(--ease-out) infinite;
+  --animation-bounce: bounce 2s var(--ease-squish) infinite;
+  --animation-pulse: pulse 2s var(--ease-out) infinite;
+
+  @keyframes spin {
+    to {
+      transform: rotate(1turn);
+    }
+  }
+  @keyframes ping {
+    90%,
+    100% {
+      transform: scale(2);
+      opacity: 0;
+    }
+  }
+  @keyframes blink {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+  @keyframes float {
+    50% {
+      transform: translateY(-25%);
+    }
+  }
+  @keyframes bounce {
+    25% {
+      transform: translateY(-20%);
+    }
+    40% {
+      transform: translateY(-3%);
+    }
+    0%,
+    60%,
+    100% {
+      transform: translateY(0);
+    }
+  }
+  @keyframes pulse {
+    50% {
+      transform: scale(0.9, 0.9);
+    }
+  }
+
   --border-radius-small: 0.125rem;
   --border-radius-medium: 0.25rem;
   --border-radius-large: 0.5rem;


### PR DESCRIPTION
This PR introduces new features in `transitions` showcases:

- `--transition` prefix is still supported but deprecated, should be replaced by `--time`
- support for `mode` allowing to override the render type rather than detecting it _via_ the CSS Custom Property prefix (fix #32)
- add support for `ease` and `animation` custom properties to showcases [CSS `timing-functions`](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function) and [CSS `animations`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation)

Demo in Backlight: https://backlight.dev/edit/4BeMe20hqOWTkdUL2NuJ/css-showcases/stories/css-showcases.stories.js?branch=css-showcases-modes%40QyIjO3Opm0S4QYLfACyef1GvBgA2&p=stories