### PR TITLE
feat(mdjs-layout): upgrade tailwind typography which does not need normalize

### DIFF
--- a/doc-layout/src/template.js
+++ b/doc-layout/src/template.js
@@ -29,6 +29,6 @@ export const docLayoutTemplate = (content, context) => html`
     <div class="logo" slot="logo" aria-label="dockit-core">
       ${unsafeHTML(logoSvg)}
     </div>
-    <div class="prose dark:prose-dark">${unsafeHTML(content)}</div>
+    <div class="prose dark:prose-invert">${unsafeHTML(content)}</div>
   </mdjs-layout>
 `;

--- a/mdjs-layout/doc/index.md
+++ b/mdjs-layout/doc/index.md
@@ -46,15 +46,15 @@ export default {
         }
       }}"
     >
-      <div class="prose dark:prose-dark">${unsafeHTML(content)}</div>
+      <div class="prose dark:prose-invert">${unsafeHTML(content)}</div>
     </mdjs-layout>
   `,
 };
 ```
 
-The `@color-scheme-change` handler manually adds a class `dark` on the `<html>` based on the initial state of the component (or user configuration) and is required for `prose dark:prose-dark` ([Tailwind-based typography classes](https://github.com/tailwindlabs/tailwindcss-typography)) to switch styles correctly when light/dark mode is switched.
+The `@color-scheme-change` handler manually adds a class `dark` on the `<html>` based on the initial state of the component (or user configuration) and is required for `prose dark:prose-invert` ([Tailwind-based typography classes](https://github.com/tailwindlabs/tailwindcss-typography)) to switch styles correctly when light/dark mode is switched.
 
-Optionally you can get rid of `prose dark:prose-dark` and force a specific theme by manually adding `dark` to the body.
+Optionally you can get rid of `prose dark:prose-invert` and force a specific theme by manually adding `dark` to the body.
 Or you can implement your own light/dark theme, thanks to the fact that the content is located in Light DOM.
 
 If you plan to use `<mdjs-layout>` without Backlight/`mdjs.config.js`, then just put your content in the default slot by any means you have, but keep in mind that if the content is rendered dynamically, then it must come from a trusted source, because scripts inside it might be executed depending on the means you choose to render.
@@ -173,14 +173,14 @@ export default {
       }}"
     >
       ...
-      <div class="prose dark:prose-dark">${unsafeHTML(content)}</div>
+      <div class="prose dark:prose-invert">${unsafeHTML(content)}</div>
       ...
     </mdjs-layout>
   `,
 };
 ```
 
-As seen in the example above, the `dark` class on the `<html>` is useful for styling anything in light/dark modes, and not only for `prose dark:prose-dark` to work correctly.
+As seen in the example above, the `dark` class on the `<html>` is useful for styling anything in light/dark modes, and not only for `prose dark:prose-invert` to work correctly.
 The general approach is to first style the light mode and then use `html.dark` selector to style the dark mode.
 
 ### Configuring mdjs-layout theme
@@ -202,7 +202,7 @@ You can also disable color scheme changing, e.g. when your design system has onl
 ### Content theme
 
 Content is part of the Light DOM and can be styled directly.
-The `styles` imported from `@divriots/dockit-core/mdjs-layout` include `normalize` styles, styles for the content typography (including light/dark modes), Prism theme for the code highlighting, code block styles (including live demo wrappers based on MDJS stories), and some other styles for various things.
+The `styles` imported from `@divriots/dockit-core/mdjs-layout` include styles for the content typography (including light/dark modes), Prism theme for the code highlighting, code block styles (including live demo wrappers based on MDJS stories), and some other styles for various things.
 As such `styles` is quite opinionated, but it is mostly composed of other individual libraries which you can import separately and adjust to your own needs.
 We recommened checking the content of `styles` to learn more about the default setup.
 

--- a/mdjs-layout/src/misc.css
+++ b/mdjs-layout/src/misc.css
@@ -1,3 +1,9 @@
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial,
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+}
+
 mdjs-layout [slot='logo'] > :first-child {
   width: auto;
   height: 3em;
@@ -7,11 +13,29 @@ mdjs-layout [slot='logo'] > :first-child {
   max-width: unset;
 }
 
-.prose ol,
-.prose ul {
-  list-style: none;
-  margin: 0;
+/* copied from typography styles */
+/* double-class is due to a specificity war with the Prism theme */
+.prose.prose :where(pre):not(:where([class~='not-prose'] *)) {
+  font-weight: 400;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+  margin-top: 1.7142857em;
+  margin-bottom: 1.7142857em;
+  padding-top: 0.8571429em;
+  padding-right: 1.1428571em;
+  padding-bottom: 0.8571429em;
+  padding-left: 1.1428571em;
+}
+
+/* copied from typography styles */
+/* double-class is due to a specificity war with the Prism theme */
+.prose.prose :where(pre code):not(:where([class~='not-prose'] *)) {
   padding: 0;
+  font-weight: inherit;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
 }
 
 .preview-story {
@@ -43,7 +67,8 @@ mdjs-layout [slot='logo'] > :first-child {
   background-color: #d4d4d4;
 }
 
-.preview-story pre {
+/* double-class is due to a specificity war with typography and Prism theme */
+.preview-story.preview-story pre {
   border: 0;
   border-radius: 0;
   margin: 0;
@@ -65,10 +90,4 @@ html.dark .preview-story details {
 
 html.dark .preview-story summary {
   background-color: #262626;
-}
-
-/* workaround selector specificity issue between Prism theme and tailwind typography */
-.prose pre,
-html.dark .dark\:prose-dark pre {
-  background-color: #1e1e1e;
 }

--- a/mdjs-layout/src/styles.css
+++ b/mdjs-layout/src/styles.css
@@ -1,4 +1,3 @@
-@import 'https://cdn.jsdelivr.net/npm/modern-normalize@1.1.0/modern-normalize.min.css';
 @import 'https://cdn.jsdelivr.net/npm/prism-themes@1.9.0/themes/prism-vsc-dark-plus.min.css';
-@import 'https://cdn.jsdelivr.net/npm/dark-tailwindcss-typography@0.4.1-dark.1/typography.min.css';
+@import 'https://cdn.jsdelivr.net/npm/dark-tailwindcss-typography@0.5.0-dark.0/typography.min.css';
 @import './misc.css';


### PR DESCRIPTION
New version of typography:
- less intrusive (pay attention to `.not-prose` in the typography, it's gonna be useful)
- no need for normalize (@jorenbroekema 🎉 )
- based on CSS vars, which we can document at some point too for people to easily customise (big win!)

Some issues:
- [x] specificity war with the Prism theme