### PR TITLE
Bugfixes for starter-vue3

### DIFF
--- a/css-showcases/src/CssShowcases.js
+++ b/css-showcases/src/CssShowcases.js
@@ -43,7 +43,7 @@ export class CssShowcases extends HTMLElement {
         _mode,
         prefix.includes('transition')
       );
-      if (prefix.includes('transition'))
+      if (prefix.includes('transition') && !this.hasAttribute('mode'))
         this.innerHTML =
           this.innerHTML +
           /*html*/

--- a/mdjs-layout/src/mdjs-layout.styles.js
+++ b/mdjs-layout/src/mdjs-layout.styles.js
@@ -283,6 +283,8 @@ export const mdjsLayoutStyles = /*css*/ `
       var(--private--mdjs-layout-header-height) + 2 *
         var(--private--mdjs-layout-spacer)
     );
+    position: relative;
+    z-index: 1;
   }
 
   .content {


### PR DESCRIPTION
z-index addition is needed to make sure this problem is fixed

![image](https://user-images.githubusercontent.com/137844/151842727-4c45694b-5572-4324-bc76-7049e4ddad10.png)

and the deprecation message introduced earlier suggests a solution to use `mode="time"`, but when this solution is applied, the deprecation message is still shown, so we need to hide it in that case