### PR TITLE
fix(css-showcases): fix multiple instances of transition showcases

### DIFF
--- a/css-showcases/src/CssShowcases.js
+++ b/css-showcases/src/CssShowcases.js
@@ -39,6 +39,7 @@ export class CssShowcases extends HTMLElement {
           ? 'animation'
           : null;
       this.innerHTML = getTransitionsHtml(
+        this,
         props,
         _mode,
         prefix.includes('transition')

--- a/css-showcases/src/transition-helper.js
+++ b/css-showcases/src/transition-helper.js
@@ -1,6 +1,6 @@
 import styles from './transition-box.module.scss';
 
-export const getTransitionsHtml = (props, mode) => {
+export const getTransitionsHtml = (element, props, mode) => {
   function style(name) {
     let rules = [];
     if (mode === 'animation') {
@@ -22,7 +22,7 @@ export const getTransitionsHtml = (props, mode) => {
   }
 
   setTimeout(() => {
-    const boxes = document.querySelectorAll('.transitionBox');
+    const boxes = element.querySelectorAll('.transitionBox');
     const toggle = mode === 'animation' ? 'no-anim' : 'clicked';
     boxes.forEach((box) =>
       box.addEventListener('click', () => {


### PR DESCRIPTION
Fixes situation when last `<dockit-css-showcases>` which demoes transition/animations breaks previous instances on the same page. Fix is needed in docs where multiple `<dockit-css-showcases>` can be present easily on the same page.