### PR TITLE
fix(mdjs-layout): avoid partial matches leading to multiple current navigation items

### DIFF
--- a/mdjs-layout/src/mdjs-layout.ts
+++ b/mdjs-layout/src/mdjs-layout.ts
@@ -325,7 +325,9 @@ export class MdjsLayout extends HTMLElement {
                                         this.relativeUrl(item.page.url)
                                       )}"
                                       aria-current="${
-                                        location.href.endsWith(item.page.url)
+                                        location.href.endsWith(
+                                          '/' + item.page.url
+                                        )
                                           ? 'location'
                                           : ''
                                       }"


### PR DESCRIPTION
Prevents issues like this

<img src="https://user-images.githubusercontent.com/137844/153464351-98c94fef-5bc4-4a57-a39c-f0bfc543d923.png" width="200">
