### PR TITLE
fix(mdjs-layout): enforce scroll bar on short pages

### DIFF
--- a/mdjs-layout/src/misc.css
+++ b/mdjs-layout/src/misc.css
@@ -2,6 +2,7 @@ body {
   margin: 0;
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  overflow-y: scroll;
 }
 
 mdjs-layout [slot='logo'] > :first-child {


### PR DESCRIPTION
On some short pages there might be not enough content to display a scrollbar. This is an issue causing layout shifts (e.g. when navigating between different pages) demonstrated in the video below, so we should enforce a scrollbar to prevent it.

https://user-images.githubusercontent.com/137844/153645978-5ac30d1d-441d-45eb-a4a6-a53bab50b593.mp4