### PR TITLE
Small incompatible fixes

### DIFF
--- a/box/dockit-box.define.js
+++ b/box/dockit-box.define.js
@@ -1,2 +1,2 @@
-import { Box } from './Box';
+import { Box } from './src/Box';
 customElements.define('dockit-box', Box);

--- a/box/index.js
+++ b/box/index.js
@@ -1,1 +1,0 @@
-export * from './src';

--- a/box/src/Box.js
+++ b/box/src/Box.js
@@ -2,10 +2,7 @@ import styles from './Box.module.css';
 
 export class Box extends HTMLElement {
   connectedCallback() {
-    const shouldShowCheckedBackground =
-      (this.hasAttribute('checkered-background') &&
-        this.getAttribute('checkered-background') !== 'false') ||
-      !this.hasAttribute('checkered-background'); // enable checkered background by default
+    const hasCheckedBackground = this.hasAttribute('checkered-background');
 
     const className = this.getAttribute('class-name') || '';
     const style = this.getAttribute('showcase-style') || '';
@@ -13,7 +10,7 @@ export class Box extends HTMLElement {
     this.innerHTML = /*html*/ `
       <div class="${styles.wrapper}">
         ${
-          shouldShowCheckedBackground
+          hasCheckedBackground
             ? `<div class="${styles.checkered} ${className}"></div>`
             : ''
         }

--- a/box/src/index.js
+++ b/box/src/index.js
@@ -1,1 +1,0 @@
-export * from './DockitBox';

--- a/box/stories/box.stories.js
+++ b/box/stories/box.stories.js
@@ -8,13 +8,13 @@ export default {
 };
 
 export const box = () =>
-  /*html*/ `<dockit-box checkered-background class-name="boxStory"></dockit-box>`;
+  /*html*/ `<dockit-box class-name="boxStory"></dockit-box>`;
 
 export const box_background = () =>
-  /*html*/ `<dockit-box checkered-background class-name="boxStory boxStoryBackground"></dockit-box>`;
+  /*html*/ `<dockit-box class-name="boxStory boxStoryBackground"></dockit-box>`;
 
 export const box_background_opacity = () =>
   /*html*/ `<dockit-box checkered-background class-name="boxStory boxStoryBackground boxStoryOpacity"></dockit-box>`;
 
 export const box_background_roundness = () =>
-  /*html*/ `<dockit-box checkered-background class-name="boxStory boxStoryBackground boxStoryRoundness"></dockit-box>`;
+  /*html*/ `<dockit-box class-name="boxStory boxStoryBackground boxStoryRoundness"></dockit-box>`;

--- a/box/stories/box.stories.js
+++ b/box/stories/box.stories.js
@@ -1,4 +1,4 @@
-import '../index.js';
+import '../dockit-box.define.js';
 import './box-stories.css';
 
 export default {

--- a/caption/dockit-caption.define.js
+++ b/caption/dockit-caption.define.js
@@ -1,3 +1,3 @@
-import { Caption } from './Caption';
+import { Caption } from './src/Caption';
 
 customElements.define('dockit-caption', Caption);

--- a/caption/index.js
+++ b/caption/index.js
@@ -1,1 +1,0 @@
-export * from './src';

--- a/caption/src/index.js
+++ b/caption/src/index.js
@@ -1,1 +1,0 @@
-export * from './DockitCaption';

--- a/caption/stories/caption.stories.js
+++ b/caption/stories/caption.stories.js
@@ -1,4 +1,4 @@
-import '../index.js';
+import '../dockit-caption.define.js';
 
 export default {
   parameters: {

--- a/css-showcases/dockit-css-showcases.define.js
+++ b/css-showcases/dockit-css-showcases.define.js
@@ -1,3 +1,3 @@
-import { CssShowcases } from './CssShowcases';
+import { CssShowcases } from './src/CssShowcases';
 
 customElements.define('dockit-css-showcases', CssShowcases);

--- a/css-showcases/index.js
+++ b/css-showcases/index.js
@@ -1,2 +1,0 @@
-export * from './src/css-props';
-export * from './src/DockitCssShowcases';

--- a/css-showcases/src/CssShowcases.js
+++ b/css-showcases/src/CssShowcases.js
@@ -1,4 +1,4 @@
-import '~/showcases';
+import '~/showcases/dockit-showcases.define.js';
 import { getCssCustomProps } from './css-props';
 import { getZIndexHtml } from './z-index-helper';
 import { getScaleHtml } from './space-helper';

--- a/css-showcases/src/CssShowcases.js
+++ b/css-showcases/src/CssShowcases.js
@@ -66,8 +66,8 @@ export class CssShowcases extends HTMLElement {
     }
 
     const componentClass = this.getAttribute('component-class');
-    const useLongText = this.getAttribute('long-text');
-    const checkeredBackground = this.getAttribute('checkered-background');
+    const hasLongText = this.hasAttribute('long-text');
+    const hasCheckeredBackground = this.hasAttribute('checkered-background');
     const showcaseStyles = props
       .map(([name]) => `${styleKey}: var(${name});`)
       .join(' ');
@@ -79,8 +79,8 @@ export class CssShowcases extends HTMLElement {
           component-class="${componentClass}"
           showcase-styles="${showcaseStyles}"
           component-type="${componentType}"
-          long-text="${useLongText}"
-          checkered-background="${checkeredBackground}"
+          ${hasLongText ? 'long-text' : ''}
+          ${hasCheckeredBackground ? 'checkered-background' : ''}
       >
       </dockit-showcases>`;
   }

--- a/css-showcases/stories/css-showcases.stories.js
+++ b/css-showcases/stories/css-showcases.stories.js
@@ -1,4 +1,4 @@
-import '../index';
+import '../dockit-css-showcases.define.js';
 import './css-showcases.css';
 import './tokens.scss';
 

--- a/showcases/dockit-showcases.define.js
+++ b/showcases/dockit-showcases.define.js
@@ -1,3 +1,3 @@
-import { Showcases } from './Showcases';
+import { Showcases } from './src/Showcases';
 
 customElements.define('dockit-showcases', Showcases);

--- a/showcases/index.js
+++ b/showcases/index.js
@@ -1,1 +1,0 @@
-export * from './src';

--- a/showcases/src/CaptionedBox.js
+++ b/showcases/src/CaptionedBox.js
@@ -9,12 +9,12 @@ export class CaptionedBox extends HTMLElement {
     const showcaseStyle = this.getAttribute('showcase-style');
     const captionWidth = this.getAttribute('caption-width');
     const componentClass = this.getAttribute('class-name');
-    const checkeredBackground = this.getAttribute('checkered-background');
+    const hasCheckeredBackground = this.hasAttribute('checkered-background');
 
     this.innerHTML = /*html*/ `
 <div class="${styles.container}">
   <dockit-box
-    checkered-background="${checkeredBackground}"
+    ${hasCheckeredBackground ? 'checkered-background' : ''}
     class-name="${showcaseClass} ${componentClass}"
     showcase-style="${showcaseStyle}"
   ></dockit-box>

--- a/showcases/src/CaptionedBox.js
+++ b/showcases/src/CaptionedBox.js
@@ -1,6 +1,6 @@
 import styles from './CaptionedBox.module.css';
-import '~/box';
-import '~/caption';
+import '~/box/dockit-box.define.js';
+import '~/caption/dockit-caption.define.js';
 import { getCaption } from './caption-helper';
 
 export class CaptionedBox extends HTMLElement {

--- a/showcases/src/CaptionedText.js
+++ b/showcases/src/CaptionedText.js
@@ -1,6 +1,6 @@
 import styles from './CaptionedText.module.css';
-import '~/caption';
-import '~/text';
+import '~/caption/dockit-caption.define.js';
+import '~/text/dockit-text.define.js';
 import { getCaption } from './caption-helper';
 
 export class CaptionedText extends HTMLElement {

--- a/showcases/src/CaptionedText.js
+++ b/showcases/src/CaptionedText.js
@@ -8,7 +8,7 @@ export class CaptionedText extends HTMLElement {
     const showcaseClass = this.getAttribute('showcase-class');
     const showcaseStyle = this.getAttribute('showcase-style');
     const captionWidth = this.getAttribute('caption-width');
-    const useLongText = this.getAttribute('long-text');
+    const hasLongText = this.hasAttribute('long-text');
 
     this.innerHTML = /*html*/ `
 <div class="${styles.container}">
@@ -16,7 +16,11 @@ export class CaptionedText extends HTMLElement {
     text="${getCaption(showcaseClass, showcaseStyle)}"
     width="${captionWidth}"
   ></dockit-caption>
-  <dockit-text long-text="${useLongText}" class="${showcaseClass}" style="${showcaseStyle}"></dockit-text>
+  <dockit-text
+    ${hasLongText ? 'long-text' : ''}
+    class="${showcaseClass}"
+    style="${showcaseStyle}"
+  ></dockit-text>
 </div>`;
   }
 }

--- a/showcases/src/DockitCaptionedBox.js
+++ b/showcases/src/DockitCaptionedBox.js
@@ -1,3 +1,0 @@
-import { CaptionedBox } from './CaptionedBox.js';
-
-customElements.define('dockit-captioned-box', CaptionedBox);

--- a/showcases/src/DockitCaptionedText.js
+++ b/showcases/src/DockitCaptionedText.js
@@ -1,3 +1,0 @@
-import { CaptionedText } from './CaptionedText';
-
-customElements.define('dockit-captioned-text', CaptionedText);

--- a/showcases/src/Showcases.js
+++ b/showcases/src/Showcases.js
@@ -1,7 +1,10 @@
+import { CaptionedBox } from './CaptionedBox.js';
+import { CaptionedText } from './CaptionedText';
 import styles from './Showcases.module.css';
-import './DockitCaptionedBox';
-import './DockitCaptionedText';
 import { getCaption } from './caption-helper';
+
+customElements.define('dockit-captioned-box', CaptionedBox);
+customElements.define('dockit-captioned-text', CaptionedText);
 
 export class Showcases extends HTMLElement {
   connectedCallback() {

--- a/showcases/src/Showcases.js
+++ b/showcases/src/Showcases.js
@@ -10,7 +10,7 @@ export class Showcases extends HTMLElement {
       type === 'box' ? 'dockit-captioned-box' : 'dockit-captioned-text';
 
     const componentClass = this.getAttribute('component-class');
-    const checkeredBackground = this.getAttribute('checkered-background');
+    const hasCheckeredBackground = this.hasAttribute('checkered-background');
 
     const showcaseClasses = this.getAttribute('showcase-classes');
     const showcaseStyles = this.getAttribute('showcase-styles');
@@ -23,7 +23,7 @@ export class Showcases extends HTMLElement {
       .filter((c) => !!c)
       .map((c) => c.trim());
 
-    const useLongText = this.getAttribute('long-text');
+    const hasLongText = this.hasAttribute('long-text');
     const longestName = showcases
       .map((val) =>
         getCaption(!!showcaseClasses && val, !!showcaseStyles && val)
@@ -37,9 +37,9 @@ export class Showcases extends HTMLElement {
         <${showcaseComponent}
           class-name="${componentClass}"
           ${showcaseAttr}="${showcase}"
-          long-text="${useLongText}"
+          ${hasLongText ? 'long-text' : ''}
           caption-width="${captionWidth}"
-          checkered-background="${checkeredBackground}"
+          ${hasCheckeredBackground ? 'checkered-background' : ''}
         ></${showcaseComponent}>`,
       ''
     );

--- a/showcases/src/index.js
+++ b/showcases/src/index.js
@@ -1,3 +1,0 @@
-export * from './DockitShowcases.js';
-export * from './DockitCaptionedText.js';
-export * from './DockitCaptionedBox.js';

--- a/showcases/stories/showcases.stories.js
+++ b/showcases/stories/showcases.stories.js
@@ -1,4 +1,4 @@
-import '../index.js';
+import '../dockit-showcases.define.js';
 import './showcases-stories.css';
 
 export const opacity_classes = () => {

--- a/space/dockit-space.define.js
+++ b/space/dockit-space.define.js
@@ -1,3 +1,3 @@
-import { Space } from './Space';
+import { Space } from './src/Space';
 
 customElements.define('dockit-space', Space);

--- a/space/index.js
+++ b/space/index.js
@@ -1,1 +1,0 @@
-export * from './src';

--- a/space/src/index.js
+++ b/space/src/index.js
@@ -1,1 +1,0 @@
-export * from './DockitSpace';

--- a/space/stories/space.stories.js
+++ b/space/stories/space.stories.js
@@ -1,4 +1,4 @@
-import '../index';
+import '../dockit-space.define.js';
 import { html } from 'lit';
 
 export const space_numbers_array_scale = () => html`<dockit-space

--- a/tailwind-showcases/dockit-tailwind-showcases.define.js
+++ b/tailwind-showcases/dockit-tailwind-showcases.define.js
@@ -1,3 +1,3 @@
-import { TailwindShowcases } from './TailwindShowcases';
+import { TailwindShowcases } from './src/TailwindShowcases';
 
 customElements.define('dockit-tailwind-showcases', TailwindShowcases);

--- a/tailwind-showcases/index.js
+++ b/tailwind-showcases/index.js
@@ -1,1 +1,0 @@
-export * from './src';

--- a/tailwind-showcases/src/TailwindShowcases.js
+++ b/tailwind-showcases/src/TailwindShowcases.js
@@ -1,4 +1,4 @@
-import '~/showcases';
+import '~/showcases/dockit-showcases.define.js';
 import { extractClassSuffixes } from './theme-helpers';
 import { getZIndexHtml } from './z-index-helper';
 import { getScaleHtml } from './space-helper';

--- a/tailwind-showcases/src/TailwindShowcases.js
+++ b/tailwind-showcases/src/TailwindShowcases.js
@@ -106,8 +106,8 @@ export class TailwindShowcases extends HTMLElement {
     const { classes, componentType } = classNames[showcaseKey];
 
     const componentClass = this.getAttribute('component-class');
-    const useLongText = this.getAttribute('long-text');
-    const checkeredBackground = this.getAttribute('checkered-background');
+    const hasLongText = this.hasAttribute('long-text');
+    const hasCheckeredBackground = this.hasAttribute('checkered-background');
 
     this.innerHTML =
       this.innerHTML +
@@ -116,8 +116,8 @@ export class TailwindShowcases extends HTMLElement {
           component-class="${componentClass}"
           showcase-classes="${classes.join(' ')}"
           component-type="${componentType}"
-          long-text="${useLongText}"
-          checkered-background="${checkeredBackground}"
+          ${hasLongText ? 'long-text' : ''}
+          ${hasCheckeredBackground ? 'checkered-background' : ''}
       ></dockit-showcases>`;
   }
 }

--- a/tailwind-showcases/src/index.js
+++ b/tailwind-showcases/src/index.js
@@ -1,1 +1,0 @@
-export * from './DockitTailwindShowcases';

--- a/tailwind-showcases/stories/tailwind-showcases.stories.js
+++ b/tailwind-showcases/stories/tailwind-showcases.stories.js
@@ -46,7 +46,6 @@ export const border_width = () => html`<dockit-tailwind-showcases
 export const border_color = () => html`<dockit-tailwind-showcases
   .theme=${twTheme}
   showcase-key="borderColor"
-  checkered-background="false"
   component-class="h-24 w-24 border-4 rounded"
 ></dockit-tailwind-showcases>`;
 

--- a/tailwind-showcases/stories/tailwind-showcases.stories.js
+++ b/tailwind-showcases/stories/tailwind-showcases.stories.js
@@ -1,4 +1,4 @@
-import '../index';
+import '../dockit-tailwind-showcases.define.js';
 import 'twind/shim';
 import twTheme from 'tailwindcss/defaultTheme.js';
 import { html } from 'lit';

--- a/text/dockit-text.define.js
+++ b/text/dockit-text.define.js
@@ -1,3 +1,3 @@
-import { Text } from './Text';
+import { Text } from './src/Text';
 
 customElements.define('dockit-text', Text);

--- a/text/index.js
+++ b/text/index.js
@@ -1,1 +1,0 @@
-export * from './src';

--- a/text/src/Text.js
+++ b/text/src/Text.js
@@ -4,10 +4,6 @@ const shortText = 'The quick brown fox jumps over the lazy dog.';
 
 export class Text extends HTMLElement {
   connectedCallback() {
-    const lt = this.getAttribute('long-text');
-    const useLongText =
-      this.hasAttribute('long-text') && lt !== 'false' && lt !== 'null';
-
-    this.innerHTML = useLongText ? longText : shortText;
+    this.innerHTML = this.hasAttribute('long-text') ? longText : shortText;
   }
 }

--- a/text/src/index.js
+++ b/text/src/index.js
@@ -1,1 +1,0 @@
-export * from './DockitText';

--- a/text/stories/text.stories.js
+++ b/text/stories/text.stories.js
@@ -1,4 +1,4 @@
-import '../index.js';
+import '../dockit-text.define.js';
 
 export default {
   parameters: {


### PR DESCRIPTION
Time to clean up 2 things:
- introduce clear separation between `index.js` entry point with 0 side effects and `component-name.define.js` with WC registration side effect
- refactor "boolean attributes" to behave using a best practice way (present = true, not present = false... actual value if present doesn't matter), remove hacks with `bool-attribute="false"` which is not really needed