### PR TITLE
feat: make checkered-background always

### DIFF
--- a/box/src/Box.js
+++ b/box/src/Box.js
@@ -2,18 +2,12 @@ import styles from './Box.module.css';
 
 export class Box extends HTMLElement {
   connectedCallback() {
-    const hasCheckedBackground = this.hasAttribute('checkered-background');
-
     const className = this.getAttribute('class-name') || '';
     const style = this.getAttribute('showcase-style') || '';
 
     this.innerHTML = /*html*/ `
       <div class="${styles.wrapper}">
-        ${
-          hasCheckedBackground
-            ? `<div class="${styles.checkered} ${className}"></div>`
-            : ''
-        }
+        <div class="${styles.checkered} ${className}"></div>
         <div class="${className}" style="${style}"></div>
       </div>
       `;

--- a/box/stories/box.stories.js
+++ b/box/stories/box.stories.js
@@ -14,7 +14,7 @@ export const box_background = () =>
   /*html*/ `<dockit-box class-name="boxStory boxStoryBackground"></dockit-box>`;
 
 export const box_background_opacity = () =>
-  /*html*/ `<dockit-box checkered-background class-name="boxStory boxStoryBackground boxStoryOpacity"></dockit-box>`;
+  /*html*/ `<dockit-box class-name="boxStory boxStoryBackground boxStoryOpacity"></dockit-box>`;
 
 export const box_background_roundness = () =>
   /*html*/ `<dockit-box class-name="boxStory boxStoryBackground boxStoryRoundness"></dockit-box>`;

--- a/css-showcases/src/CssShowcases.js
+++ b/css-showcases/src/CssShowcases.js
@@ -67,7 +67,6 @@ export class CssShowcases extends HTMLElement {
 
     const componentClass = this.getAttribute('component-class');
     const hasLongText = this.hasAttribute('long-text');
-    const hasCheckeredBackground = this.hasAttribute('checkered-background');
     const showcaseStyles = props
       .map(([name]) => `${styleKey}: var(${name});`)
       .join(' ');
@@ -80,7 +79,6 @@ export class CssShowcases extends HTMLElement {
           showcase-styles="${showcaseStyles}"
           component-type="${componentType}"
           ${hasLongText ? 'long-text' : ''}
-          ${hasCheckeredBackground ? 'checkered-background' : ''}
       >
       </dockit-showcases>`;
   }

--- a/showcases/src/CaptionedBox.js
+++ b/showcases/src/CaptionedBox.js
@@ -9,12 +9,10 @@ export class CaptionedBox extends HTMLElement {
     const showcaseStyle = this.getAttribute('showcase-style');
     const captionWidth = this.getAttribute('caption-width');
     const componentClass = this.getAttribute('class-name');
-    const hasCheckeredBackground = this.hasAttribute('checkered-background');
 
     this.innerHTML = /*html*/ `
 <div class="${styles.container}">
   <dockit-box
-    ${hasCheckeredBackground ? 'checkered-background' : ''}
     class-name="${showcaseClass} ${componentClass}"
     showcase-style="${showcaseStyle}"
   ></dockit-box>

--- a/showcases/src/Showcases.js
+++ b/showcases/src/Showcases.js
@@ -13,7 +13,6 @@ export class Showcases extends HTMLElement {
       type === 'box' ? 'dockit-captioned-box' : 'dockit-captioned-text';
 
     const componentClass = this.getAttribute('component-class');
-    const hasCheckeredBackground = this.hasAttribute('checkered-background');
 
     const showcaseClasses = this.getAttribute('showcase-classes');
     const showcaseStyles = this.getAttribute('showcase-styles');
@@ -42,7 +41,6 @@ export class Showcases extends HTMLElement {
           ${showcaseAttr}="${showcase}"
           ${hasLongText ? 'long-text' : ''}
           caption-width="${captionWidth}"
-          ${hasCheckeredBackground ? 'checkered-background' : ''}
         ></${showcaseComponent}>`,
       ''
     );

--- a/tailwind-showcases/src/TailwindShowcases.js
+++ b/tailwind-showcases/src/TailwindShowcases.js
@@ -107,7 +107,6 @@ export class TailwindShowcases extends HTMLElement {
 
     const componentClass = this.getAttribute('component-class');
     const hasLongText = this.hasAttribute('long-text');
-    const hasCheckeredBackground = this.hasAttribute('checkered-background');
 
     this.innerHTML =
       this.innerHTML +
@@ -117,7 +116,6 @@ export class TailwindShowcases extends HTMLElement {
           showcase-classes="${classes.join(' ')}"
           component-type="${componentType}"
           ${hasLongText ? 'long-text' : ''}
-          ${hasCheckeredBackground ? 'checkered-background' : ''}
       ></dockit-showcases>`;
   }
 }


### PR DESCRIPTION
It used to be the default anyway due to a bug in attribute propagation in most components except the main `dockit-box` one. I'm basically cleaning this without worrying it's gonna break the usage for people and I think it's needed anyway by default always.

Also, as Georges pointed out in https://github.com/divriots/dockit-core/pull/52#discussion_r808747141, people can make another box class if needed to override the checkered styles.