### PR TITLE
Tailwind automatic attributes for checkered-background and long-text

### DIFF
--- a/tailwind-showcases/src/TailwindShowcases.js
+++ b/tailwind-showcases/src/TailwindShowcases.js
@@ -21,10 +21,12 @@ const getClassNames = (suffixes) => ({
   backgroundColor: {
     componentType: 'box',
     classes: suffixes.colors.map((s) => `bg${s}`),
+    requiresCheckeredBackground: true,
   },
   opacity: {
     componentType: 'box',
     classes: suffixes.opacity.map((s) => `opacity${s}`),
+    requiresCheckeredBackground: true,
   },
   shadow: {
     componentType: 'box',
@@ -103,11 +105,11 @@ export class TailwindShowcases extends HTMLElement {
       return;
     }
 
-    const { classes, componentType } = classNames[showcaseKey];
+    const { classes, componentType, requiresCheckeredBackground } =
+      classNames[showcaseKey];
 
     const componentClass = this.getAttribute('component-class');
     const hasLongText = this.hasAttribute('long-text');
-    const hasCheckeredBackground = this.hasAttribute('checkered-background');
 
     this.innerHTML =
       this.innerHTML +
@@ -117,7 +119,7 @@ export class TailwindShowcases extends HTMLElement {
           showcase-classes="${classes.join(' ')}"
           component-type="${componentType}"
           ${hasLongText ? 'long-text' : ''}
-          ${hasCheckeredBackground ? 'checkered-background' : ''}
+          ${requiresCheckeredBackground ? 'checkered-background' : ''}
       ></dockit-showcases>`;
   }
 }

--- a/tailwind-showcases/src/TailwindShowcases.js
+++ b/tailwind-showcases/src/TailwindShowcases.js
@@ -67,6 +67,7 @@ const getClassNames = (suffixes) => ({
   lineHeight: {
     componentType: 'text',
     classes: suffixes.lineHeight.map((s) => `leading${s}`),
+    requiresLongText: true,
   },
 });
 
@@ -105,11 +106,14 @@ export class TailwindShowcases extends HTMLElement {
       return;
     }
 
-    const { classes, componentType, requiresCheckeredBackground } =
-      classNames[showcaseKey];
+    const {
+      classes,
+      componentType,
+      requiresLongText,
+      requiresCheckeredBackground,
+    } = classNames[showcaseKey];
 
     const componentClass = this.getAttribute('component-class');
-    const hasLongText = this.hasAttribute('long-text');
 
     this.innerHTML =
       this.innerHTML +
@@ -118,7 +122,7 @@ export class TailwindShowcases extends HTMLElement {
           component-class="${componentClass}"
           showcase-classes="${classes.join(' ')}"
           component-type="${componentType}"
-          ${hasLongText ? 'long-text' : ''}
+          ${requiresLongText ? 'long-text' : ''}
           ${requiresCheckeredBackground ? 'checkered-background' : ''}
       ></dockit-showcases>`;
   }

--- a/tailwind-showcases/stories/tailwind-showcases.stories.js
+++ b/tailwind-showcases/stories/tailwind-showcases.stories.js
@@ -73,7 +73,6 @@ export const line_height = () => html`<dockit-tailwind-showcases
   .theme=${twTheme}
   showcase-key="lineHeight"
   long-text
-  componentProps={{ useLongText: true }}
 ></dockit-tailwind-showcases>`;
 
 export const text_color = () => html`<dockit-tailwind-showcases


### PR DESCRIPTION
Turned out we can't always set `checkered-background`, because there are cases (colors) where it makes sense and other cases (border-width, border-radius) where it looks weird with it. Previously there was a bug which added it in some cases for Tailwind, but not for others (also there was same bug for `long-text`). I fixed that bug and opened up a pandora box with other things broken.

This PR tries to finally find a good balance: for Tailwind it's gonna make sure `checkered-background` and `long-text` is set when needed. For other components the situation stays flexible: you know where you need it and need to add it explicitely. The follow-up PR will add clear docs on that.

I assume most of our users right now rely on `dockit-tailwind-showcases`, so this should keep backwards compatibility for them.