### PR TITLE
feat(layout): use context.base for navigation links

### DIFF
--- a/layout/src/Layout.ts
+++ b/layout/src/Layout.ts
@@ -1,4 +1,4 @@
-import type { Context } from '@divriots/studio-doc-compiler';
+import type { Context, Page } from '@divriots/studio-doc-compiler';
 import { LayoutStyles } from './Layout.styles';
 
 type ColorScheme = 'light' | 'dark';
@@ -160,11 +160,10 @@ export class Layout extends HTMLElement {
 
   private getLogoHref() {
     if (this.hasNavigation && this.context.pagesGraph[0]) {
-      return this.relativeUrl(
-        this.context.pagesGraph[0].children
-          ? this.context.pagesGraph[0].children[0].page.url
-          : this.context.pagesGraph[0].page.url
-      );
+      const page = this.context.pagesGraph[0].children
+        ? this.context.pagesGraph[0].children[0].page
+        : this.context.pagesGraph[0].page;
+      return this.getPageUrlWithoutOrigin(page);
     } else {
       return '';
     }
@@ -174,13 +173,8 @@ export class Layout extends HTMLElement {
     return !!(this.context && this.context.pagesGraph);
   }
 
-  private relativeUrl(url: string): string {
-    return [
-      Array(url.split('/').length - 1)
-        .fill('..')
-        .join('/'),
-      url,
-    ].join('/');
+  private getPageUrlWithoutOrigin(page: Page): string {
+    return this.context.base + page.url;
   }
 
   private toggleColorScheme(): void {
@@ -320,12 +314,11 @@ export class Layout extends HTMLElement {
                                   (item) => `<li>
                                     <a
                                       href="${sanitize(
-                                        this.relativeUrl(item.page.url)
+                                        this.getPageUrlWithoutOrigin(item.page)
                                       )}"
                                       aria-current="${
-                                        location.href.endsWith(
-                                          '/' + item.page.url
-                                        )
+                                        location.pathname ===
+                                        this.getPageUrlWithoutOrigin(item.page)
                                           ? 'location'
                                           : ''
                                       }"


### PR DESCRIPTION
Current implementation is hardcoded in the sense that all URLs were assuming it's relative to `/level1/level2/level3`.
This is very inflexible of course, but to be precise:
- no way to make URLs like this with a final slash `/name/doc/name/`, to make consistent with index paths like `/name/doc/`
- no way to remap URLs to make them truly readable for the exported docs (e.g. remap `/name/doc/` to just `/name/` on `http://mysite.docs/name/` with the `base = "/"`)

This PR is one of many which will follow, on adding support for base on all sides of the documentation.