### PR TITLE
feat(layout): add getter and setter for color scheme

### DIFF
--- a/layout/doc/layout.md
+++ b/layout/doc/layout.md
@@ -243,3 +243,28 @@ export default {
     `,
 };
 ```
+
+## Get/set color scheme
+
+You might want to demo your own component that switches the color scheme.
+The way how the color scheme is implemented on the page depends on your Design System, therefore `dockit-layout` doesn't force you to use it's custom way and rely on the internal implementation details.
+Instead the current value of the color scheme is exposed on the component for reading and writing, so that you can initialize the current value from the documentation site value and change it when needed to let `dockit-layout` update the internals.
+
+Let's say your component is called `color-scheme-switcher`.
+Then you need to provide a way to set it's initial value and listen to changes, so the demo code might look like this:
+
+```js
+import { html } from 'lit';
+export const story = () => html`
+  <color-scheme-switcher
+    initial-color-scheme="${document.querySelector('dockit-layout')
+      .colorScheme}"
+    @color-scheme-change="${(event) => {
+      document.querySelector('dockit-layout').colorScheme =
+        event.detail.colorScheme;
+    }}"
+  ></color-scheme-switcher>
+`;
+```
+
+`dockit-layout` understands `light` and `dark` color scheme values, so if you use different values then you need to transform them to `light` and `dark` manually.

--- a/layout/src/Layout.ts
+++ b/layout/src/Layout.ts
@@ -31,6 +31,19 @@ export class Layout extends HTMLElement {
     return this._context;
   }
 
+  set colorScheme(value: ColorScheme) {
+    const changed = this._colorScheme !== value;
+    this._colorScheme = value;
+    this.renderColorScheme();
+    if (changed) {
+      this.dispatchColorSchemeChange();
+    }
+  }
+
+  get colorScheme(): ColorScheme {
+    return this._colorScheme;
+  }
+
   private _context: Context;
 
   private _isNavigationShown: boolean = false;
@@ -185,7 +198,6 @@ export class Layout extends HTMLElement {
 
   private toggleColorScheme(): void {
     this.colorScheme = this.colorScheme === 'dark' ? 'light' : 'dark';
-    this.dispatchColorSchemeChange();
     localStorage.setItem('colorScheme', this.colorScheme);
   }
 
@@ -240,15 +252,6 @@ export class Layout extends HTMLElement {
     } else {
       this.removeAttribute('disable-color-scheme-change');
     }
-  }
-
-  private get colorScheme(): ColorScheme {
-    return this._colorScheme;
-  }
-
-  private set colorScheme(value: ColorScheme) {
-    this._colorScheme = value;
-    this.renderColorScheme();
   }
 
   private renderTemplate() {


### PR DESCRIPTION
Needed to make a demo of `ThemeSwitch` component (https://backlight.dev/edit/elVBDiiiouYQjeQ9fReN/theme-switch/src/ThemeSwitch.svelte?branch=design-color-scheme%4044v7XI9EE5hzBwU7oxi8dbGjKz03&p=doc) that @m4dz is working on.