### PR TITLE
fix(layout): prevent incorrect reset of navigation scrollTop when rerendering

### DIFF
--- a/layout/src/Layout.ts
+++ b/layout/src/Layout.ts
@@ -68,7 +68,16 @@ export class Layout extends HTMLElement {
   }
 
   private render() {
+    let prevNavigationScrollTop;
+    if (this.hasNavigation) {
+      prevNavigationScrollTop =
+        this.shadowRoot.querySelector('.navigation')?.scrollTop;
+    }
     this.shadowRoot.innerHTML = this.renderTemplate();
+    if (this.hasNavigation && prevNavigationScrollTop) {
+      this.shadowRoot.querySelector('.navigation').scrollTop =
+        prevNavigationScrollTop;
+    }
     this.$colorSchemeToggle = this.shadowRoot.querySelector(
       '.color-scheme-toggle'
     );


### PR DESCRIPTION
Bug appears when user scroll navigation to the bottom and clicks on the link.
When speedy-links is used, then the page gets rerendered without full page refresh, but the scroll of the navigation is unexpectedly reset.

This workaround is needed for now due to suboptimal rerendering mechanism.
In the future we gonna migrate all dockit-core components to Lit (or similar) and we can get rid of this code given the elements are not just fully replaced on each rerender.