### PR TITLE
fix(layout): hide navigation when link is clicked

### DIFF
--- a/layout/src/Layout.ts
+++ b/layout/src/Layout.ts
@@ -224,7 +224,10 @@ export class Layout extends LitElement {
   }
 
   private onNavigationWrapperClick(event: Event): void {
-    if (event.currentTarget === event.target) {
+    if (
+      event.target === event.currentTarget ||
+      (event.target as HTMLElement).tagName === 'A'
+    ) {
       this.hideNavigation();
     }
   }


### PR DESCRIPTION
When `speedy-links` is used, there is no page refresh, therefore we need to make sure the navigation is hidden on link click in the mobile layout.