### PR TITLE
fix(layout): scale img tag size when used directly of with div wrapper

### DIFF
--- a/layout/src/Layout.styles.ts
+++ b/layout/src/Layout.styles.ts
@@ -95,18 +95,15 @@ export const LayoutStyles = css`
   }
 
   .logo-container {
-    flex: 0;
+    display: flex;
     height: var(--private--dockit-layout-header-content-height);
     padding: var(--private--dockit-layout-spacer);
     border-bottom: 1px solid var(--private--dockit-layout-header-border-color);
   }
 
   .logo-link {
+    display: flex;
     text-decoration: none;
-  }
-
-  .logo-container ::slotted(:first-child) {
-    display: inline-block;
   }
 
   @media screen and (min-width: ${unsafeCSS(breakpoints.lg)}) {


### PR DESCRIPTION
Trying to provide useful defaults, so that most people don't need to write any styles when they just use an IMG or SVG tag.

This PR adds support for 2 scenarios when IMG tag is used in the logo slot

```html
<!-- 1 -->
<dockit-layout>
  <div slot="logo">
    <img src="..." />
  </div>
</dockit-layout>

<!-- 2 -->
<dockit-layout>
  <img src="..." slot="logo" />
</dockit-layout>
```

Previously only inline SVG worked smoothly

```html
<dockit-layout>
  <div slot="logo">
    <svg>...</svg>
  </div>
</dockit-layout>
```