### PR TITLE
feat(layout): expose default CSS props for reading

### DIFF
--- a/layout/doc/layout.md
+++ b/layout/doc/layout.md
@@ -138,7 +138,7 @@ export default {
 ```
 
 Pay attention to the usage of `breakpoints`.
-This is handy if you want to sync with the reponsive `<dockit-layout>` behavior which looks differently on different screen sizes.
+This is handy if you want to sync with the responsive `<dockit-layout>` behavior which looks differently on different screen sizes.
 Use `min-width` and think of it as mobile-first responsive layout.
 
 ## Configure the theme

--- a/layout/doc/layout.md
+++ b/layout/doc/layout.md
@@ -243,3 +243,6 @@ export default {
     `,
 };
 ```
+
+These CSS custom properties are also available for reading.
+It's handy when you create something for the `topbar` slot and want it to reuse same values.

--- a/layout/src/Layout.styles.ts
+++ b/layout/src/Layout.styles.ts
@@ -3,67 +3,85 @@ import { breakpoints } from './breakpoints';
 
 export const LayoutStyles = css`
   :host {
-    --private--dockit-layout-bg: var(--dockit-layout-bg, #ffffff);
-    --private--dockit-layout-header-border-color: var(
-      --dockit-layout-header-border-color,
+    --proxy--dockit-layout-bg: var(--dockit-layout-bg);
+    --proxy--dockit-layout-header-border-color: var(
+      --dockit-layout-header-border-color
+    );
+    --proxy--dockit-layout-toggle-button-bg: var(
+      --dockit-layout-toggle-button-bg
+    );
+    --proxy--dockit-layout-toggle-button-color: var(
+      --dockit-layout-toggle-button-color
+    );
+    --proxy--dockit-layout-navigation-group-heading-color: var(
+      --dockit-layout-navigation-group-heading-color
+    );
+    --proxy--dockit-layout-navigation-link-color: var(
+      --dockit-layout-navigation-link-color
+    );
+    --proxy--dockit-layout-navigation-current-link-color: var(
+      --dockit-layout-navigation-current-link-color
+    );
+  }
+
+  :host([data-color-scheme='light']) .root {
+    --dockit-layout-bg: var(--proxy--dockit-layout-bg, #ffffff);
+    --dockit-layout-header-border-color: var(
+      --proxy--dockit-layout-header-border-color,
       #e5e5e5
     );
-    --private--dockit-layout-toggle-button-bg: var(
-      --dockit-layout-toggle-button-bg,
+    --dockit-layout-toggle-button-bg: var(
+      --proxy--dockit-layout-toggle-button-bg,
       #737373
     );
-    --private--dockit-layout-toggle-button-color: var(
-      --dockit-layout-toggle-button-color,
+    --dockit-layout-toggle-button-color: var(
+      --proxy--dockit-layout-toggle-button-color,
       #ffffff
     );
-    --private--dockit-layout-navigation-group-heading-color: var(
-      --dockit-layout-navigation-group-heading-color,
+    --dockit-layout-navigation-group-heading-color: var(
+      --proxy--dockit-layout-navigation-group-heading-color,
       #404040
     );
-    --private--dockit-layout-navigation-link-color: var(
-      --dockit-layout-navigation-link-color,
+    --dockit-layout-navigation-link-color: var(
+      --proxy--dockit-layout-navigation-link-color,
       #171717
     );
-    --private--dockit-layout-navigation-current-link-color: var(
-      --dockit-layout-navigation-current-link-color,
+    --dockit-layout-navigation-current-link-color: var(
+      --proxy--dockit-layout-navigation-current-link-color,
       #e5e5e5
     );
   }
 
-  :host([data-color-scheme='dark']) {
-    --private--dockit-layout-bg: var(--dockit-layout-bg, #171717);
-    --private--dockit-layout-header-border-color: var(
-      --dockit-layout-header-border-color,
+  :host([data-color-scheme='dark']) .root {
+    --dockit-layout-bg: var(--proxy--dockit-layout-bg, #171717);
+    --dockit-layout-header-border-color: var(
+      --proxy--dockit-layout-header-border-color,
       #404040
     );
-    --private--dockit-layout-toggle-button-bg: var(
-      --dockit-layout-toggle-button-bg,
+    --dockit-layout-toggle-button-bg: var(
+      --proxy--dockit-layout-toggle-button-bg,
       #737373
     );
-    --private--dockit-layout-toggle-button-color: var(
-      --dockit-layout-toggle-button-color,
+    --dockit-layout-toggle-button-color: var(
+      --proxy--dockit-layout-toggle-button-color,
       #ffffff
     );
-    --private--dockit-layout-navigation-group-heading-color: var(
-      --dockit-layout-navigation-group-heading-color,
+    --dockit-layout-navigation-group-heading-color: var(
+      --proxy--dockit-layout-navigation-group-heading-color,
       #a3a3a3
     );
-    --private--dockit-layout-navigation-link-color: var(
-      --dockit-layout-navigation-link-color,
+    --dockit-layout-navigation-link-color: var(
+      --proxy--dockit-layout-navigation-link-color,
       #ffffff
     );
-    --private--dockit-layout-navigation-current-link-color: var(
-      --dockit-layout-navigation-current-link-color,
+    --dockit-layout-navigation-current-link-color: var(
+      --proxy--dockit-layout-navigation-current-link-color,
       #404040
     );
   }
 
   :host {
     display: block;
-    background-color: var(--private--dockit-layout-bg);
-    width: 100%;
-    min-height: 100vh;
-    overflow: hidden;
     --private--dockit-layout-spacer: 1rem;
     --private--dockit-layout-header-content-height: 3rem;
     --private--dockit-layout-header-height: calc(
@@ -74,6 +92,13 @@ export const LayoutStyles = css`
       --private--dockit-layout-header-content-height
     );
     --private--dockit-layout-navigation-width: 244px;
+  }
+
+  .root {
+    background-color: var(--dockit-layout-bg);
+    width: 100%;
+    min-height: 100vh;
+    overflow: hidden;
   }
 
   .fixed-container {
@@ -90,7 +115,7 @@ export const LayoutStyles = css`
 
   .header {
     display: flex;
-    background-color: var(--private--dockit-layout-bg);
+    background-color: var(--dockit-layout-bg);
     height: var(--private--dockit-layout-header-height);
   }
 
@@ -98,7 +123,7 @@ export const LayoutStyles = css`
     display: flex;
     height: var(--private--dockit-layout-header-content-height);
     padding: var(--private--dockit-layout-spacer);
-    border-bottom: 1px solid var(--private--dockit-layout-header-border-color);
+    border-bottom: 1px solid var(--dockit-layout-header-border-color);
   }
 
   .logo-link {
@@ -123,7 +148,7 @@ export const LayoutStyles = css`
     align-items: center;
     height: var(--private--dockit-layout-header-content-height);
     padding: var(--private--dockit-layout-spacer);
-    border-bottom: 1px solid var(--private--dockit-layout-header-border-color);
+    border-bottom: 1px solid var(--dockit-layout-header-border-color);
   }
 
   @media screen and (min-width: ${unsafeCSS(breakpoints.lg)}) {
@@ -146,8 +171,8 @@ export const LayoutStyles = css`
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: var(--private--dockit-layout-toggle-button-bg);
-    color: var(--private--dockit-layout-toggle-button-color);
+    background-color: var(--dockit-layout-toggle-button-bg);
+    color: var(--dockit-layout-toggle-button-color);
     cursor: pointer;
     margin-right: var(--private--dockit-layout-spacer);
     width: var(--private--dockit-layout-header-content-height);
@@ -200,7 +225,7 @@ export const LayoutStyles = css`
       content: '';
       background-image: linear-gradient(
         to bottom,
-        var(--private--dockit-layout-bg),
+        var(--dockit-layout-bg),
         #ffffff00
       );
       height: 20px;
@@ -221,7 +246,7 @@ export const LayoutStyles = css`
   }
 
   .navigation {
-    background-color: var(--private--dockit-layout-bg);
+    background-color: var(--dockit-layout-bg);
     width: var(--private--dockit-layout-navigation-width);
     height: 100vh;
     overflow-y: auto;
@@ -270,21 +295,19 @@ export const LayoutStyles = css`
   }
 
   .navigation > ul > li > span {
-    color: var(--private--dockit-layout-navigation-group-heading-color);
+    color: var(--dockit-layout-navigation-group-heading-color);
     text-transform: uppercase;
   }
 
   .navigation a {
-    color: var(--private--dockit-layout-navigation-link-color);
+    color: var(--dockit-layout-navigation-link-color);
     padding: calc(var(--private--dockit-layout-spacer) / 2);
     margin-left: calc(-1 * var(--private--dockit-layout-spacer) / 2);
     text-decoration: none;
   }
 
   .navigation a[aria-current='location'] {
-    background-color: var(
-      --private--dockit-layout-navigation-current-link-color
-    );
+    background-color: var(--dockit-layout-navigation-current-link-color);
   }
 
   .main-container {

--- a/layout/src/Layout.ts
+++ b/layout/src/Layout.ts
@@ -54,100 +54,103 @@ export class Layout extends LitElement {
   render() {
     this.renderHost();
     return html`
-      <div class="fixed-container">
-        <div class="relative-container">
-          <header class="header">
-            <div class="logo-container">
-              ${this.hasNavigation
-                ? html`<a class="logo-link" href="${this.getLogoHref()}">
-                    <slot name="logo"></slot>
-                  </a>`
-                : html`<slot name="logo"></slot>`}
-            </div>
-            <div class="topbar-container">
-              <slot name="topbar"></slot>
-            </div>
-            <div class="buttons-container">
-              ${this.disableColorSchemeChange
-                ? nothing
-                : html`
-                    <button
-                      class="color-scheme-toggle"
-                      aria-live="polite"
-                      aria-label="${`Press to activate ${
-                        this.colorScheme === 'dark' ? 'light' : 'dark'
-                      } mode`}"
-                      @click="${() => this.toggleColorScheme()}"
-                    >
-                      ${unsafeHTML(
-                        this.colorScheme === 'dark' ? moonSvg : sunSvg
-                      )}
-                    </button>
-                  `}
-              ${this.hasNavigation
-                ? html`
-                    <button
-                      class="navigation-toggle"
-                      aria-live="polite"
-                      aria-label="${`Press to ${
-                        this.isNavigationShown ? 'close' : 'open'
-                      } navigation`}"
-                      @click="${() => this.toggleNavigation()}"
-                    >
-                      ${unsafeHTML(this.isNavigationShown ? xSvg : menuSvg)}
-                    </button>
-                  `
-                : nothing}
-            </div>
-          </header>
-          ${this.hasNavigation
-            ? html`<div
-                class="navigation-wrapper"
-                @click="${(event) => this.onNavigationWrapperClick(event)}"
-              >
-                <nav class="navigation">
-                  <ul>
-                    ${this.context.pagesGraph
-                      .filter(
-                        (group) => !group.children || group.children.length > 0
-                      )
-                      .map(
-                        (group) => html`<li>
-                          ${group.children
-                            ? html`<span>${group.key}</span>`
-                            : nothing}
-                          <ul>
-                            ${(group.children ? group.children : [group]).map(
-                              (item) => html`<li>
-                                <a
-                                  href="${this.getPageUrlWithoutOrigin(
-                                    item.page
-                                  )}"
-                                  aria-current="${ifDefined(
-                                    location.pathname ===
-                                      this.getPageUrlWithoutOrigin(item.page)
-                                      ? 'location'
-                                      : undefined
-                                  )}"
-                                >
-                                  ${item.key}
-                                </a>
-                              </li>`
-                            )}
-                          </ul>
-                        </li>`
-                      )}
-                  </ul>
-                </nav>
-              </div>`
-            : nothing}
+      <div class="root">
+        <div class="fixed-container">
+          <div class="relative-container">
+            <header class="header">
+              <div class="logo-container">
+                ${this.hasNavigation
+                  ? html`<a class="logo-link" href="${this.getLogoHref()}">
+                      <slot name="logo"></slot>
+                    </a>`
+                  : html`<slot name="logo"></slot>`}
+              </div>
+              <div class="topbar-container">
+                <slot name="topbar"></slot>
+              </div>
+              <div class="buttons-container">
+                ${this.disableColorSchemeChange
+                  ? nothing
+                  : html`
+                      <button
+                        class="color-scheme-toggle"
+                        aria-live="polite"
+                        aria-label="${`Press to activate ${
+                          this.colorScheme === 'dark' ? 'light' : 'dark'
+                        } mode`}"
+                        @click="${() => this.toggleColorScheme()}"
+                      >
+                        ${unsafeHTML(
+                          this.colorScheme === 'dark' ? moonSvg : sunSvg
+                        )}
+                      </button>
+                    `}
+                ${this.hasNavigation
+                  ? html`
+                      <button
+                        class="navigation-toggle"
+                        aria-live="polite"
+                        aria-label="${`Press to ${
+                          this.isNavigationShown ? 'close' : 'open'
+                        } navigation`}"
+                        @click="${() => this.toggleNavigation()}"
+                      >
+                        ${unsafeHTML(this.isNavigationShown ? xSvg : menuSvg)}
+                      </button>
+                    `
+                  : nothing}
+              </div>
+            </header>
+            ${this.hasNavigation
+              ? html`<div
+                  class="navigation-wrapper"
+                  @click="${(event) => this.onNavigationWrapperClick(event)}"
+                >
+                  <nav class="navigation">
+                    <ul>
+                      ${this.context.pagesGraph
+                        .filter(
+                          (group) =>
+                            !group.children || group.children.length > 0
+                        )
+                        .map(
+                          (group) => html`<li>
+                            ${group.children
+                              ? html`<span>${group.key}</span>`
+                              : nothing}
+                            <ul>
+                              ${(group.children ? group.children : [group]).map(
+                                (item) => html`<li>
+                                  <a
+                                    href="${this.getPageUrlWithoutOrigin(
+                                      item.page
+                                    )}"
+                                    aria-current="${ifDefined(
+                                      location.pathname ===
+                                        this.getPageUrlWithoutOrigin(item.page)
+                                        ? 'location'
+                                        : undefined
+                                    )}"
+                                  >
+                                    ${item.key}
+                                  </a>
+                                </li>`
+                              )}
+                            </ul>
+                          </li>`
+                        )}
+                    </ul>
+                  </nav>
+                </div>`
+              : nothing}
+          </div>
         </div>
+        <main class="main-container">
+          <article class="content">
+            <slot></slot>
+          </article>
+        </main>
       </div>
-      <main class="main-container">
-        <article class="content">
-          <slot></slot>
-        </article>
-      </main>
     `;
   }
 


### PR DESCRIPTION
Some interesting thoughts on this can be found in
https://stackoverflow.com/questions/59015022/css-variables-defaults-set-if-not-already-set

But this PR takes the use-case further and results in the following requirements:
1. `read` access (new requirement solved by this PR)
2. `write` access
3. default values

The combination of all 3 requires an intermediate DOM node and "weird" reassignment:
1. on host: `--my-var` => `--proxy--my-var`
2. on intermediate DOM node: `--proxy--my-var` => `--my-var` with a default value

PS: btw this doesn't work (if you are wondering "why not just give a default value on host?")

```css
:host {
  --my-var: var(--my-var, "default-value")
}
```