### PR TITLE
fix(speedy-links): prevent error when hash is not a valid selector

### DIFF
--- a/speedy-links/src/speedy-links.ts
+++ b/speedy-links/src/speedy-links.ts
@@ -66,7 +66,12 @@ function pushNewUrlToHistory(url: string): void {
 }
 
 function tryScrollToHashOrResetScroll(hash?: string): void {
-  const hashEl = hash ? document.querySelector(hash) : null;
+  let hashEl;
+  if (hash) {
+    try {
+      hashEl = document.querySelector(hash);
+    } catch {}
+  }
   if (hashEl) {
     hashEl.scrollIntoView();
   } else {


### PR DESCRIPTION
e.g. when hash is `#smth20%with20%percent20%sign`