### PR TITLE
fix(layout): update current link when setting same context object

### DIFF
--- a/layout/src/Layout.ts
+++ b/layout/src/Layout.ts
@@ -40,6 +40,9 @@ export class Layout extends LitElement {
   @state()
   private colorScheme: ColorScheme;
 
+  @state()
+  private locationPathname = location.pathname;
+
   private listenerRemovers: Function[] = [];
 
   connectedCallback(): void {
@@ -52,6 +55,14 @@ export class Layout extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.teardownWindowEvents();
+  }
+
+  requestUpdate(...args): void {
+    super.requestUpdate(...args);
+    const name = args[0] as PropertyKey;
+    if (name === 'context') {
+      this.locationPathname = location.pathname;
+    }
   }
 
   render() {
@@ -129,7 +140,7 @@ export class Layout extends LitElement {
                                       item.page
                                     )}"
                                     aria-current="${ifDefined(
-                                      location.pathname ===
+                                      this.locationPathname ===
                                         this.getPageUrlWithoutOrigin(item.page)
                                         ? 'location'
                                         : undefined


### PR DESCRIPTION
Solves bug that current active link may not be updated when navigation happens to another page.

In Backlight we now create a `context` module which exports just a single `context` reference, so layout updates set the same `context` reference during navigations and content rendering.
Lit's internal strict equality check now thinks `context` didn't change (nor other props), and because of that the rerendering is not triggered.
We need another way to update current active link.

I tried different approaches:
- ideally we want to monitor some sort of `location-change` event, but platform lacks such an event, there are `popstate` and `hashchange`, but they are not generic and not suitable for `location.pathname` which we need to listen to
- `slotchange` event and MutationObserver of the content DOM: heavy and also wrong, because not related to navigation
- `hasChanged` property option: doesn't give reference to the component instance, so impossible to set or read cached `location.pathname` to do the trick
- polling of `location.pathname` value: slow and quite an overhead

Eventually I found an approach which is elegant and gives good perf: override `requestUpdate` and just use some state property for cached location pathname which will trigger update if changed together with the `context`.