### PR TITLE
fixed box checkered bg opacity by removing applied class from div

### DIFF
--- a/box/src/Box.module.css
+++ b/box/src/Box.module.css
@@ -1,11 +1,11 @@
 .wrapper {
   position: relative;
   z-index: 0;
+  overflow: hidden;
 }
 
 .checkered {
-  opacity: 1;
-  background-color: #000000;
+  opacity: 1; /* needed to avoid override by showcasing classes and styles*/
   background-image: linear-gradient(
       45deg,
       rgb(153, 153, 153) 25%,
@@ -20,4 +20,6 @@
   top: 0px;
   z-index: -1;
   box-shadow: none;
+  width: 100%;
+  height: 100%;
 }

--- a/box/src/Box.module.css
+++ b/box/src/Box.module.css
@@ -1,11 +1,9 @@
 .wrapper {
   position: relative;
   z-index: 0;
-  overflow: hidden;
 }
 
 .checkered {
-  opacity: 1; /* needed to avoid override by showcasing classes and styles*/
   background-image: linear-gradient(
       45deg,
       rgb(153, 153, 153) 25%,

--- a/box/src/Box.ts
+++ b/box/src/Box.ts
@@ -9,11 +9,7 @@ export class Box extends HTMLElement {
 
     this.innerHTML = /*html*/ `
       <div class="${styles.wrapper}">
-        ${
-          hasCheckedBackground
-            ? `<div class="${styles.checkered} ${className}"></div>`
-            : ''
-        }
+        ${hasCheckedBackground ? `<div class="${styles.checkered}"></div>` : ''}
         <div class="${className}" style="${style}"></div>
       </div>
       `;


### PR DESCRIPTION
This has the disadvantage that the checkered background div ignores other styles such as `border-radius` applied to the box - this might be an isolated corner case.

Another option would be to force `opacity: 1 !important;` and apply the showcase class as well to the checkered bg div.

I'm open to other options as well, I just didn't find a better solution.
You can see a before and after in showcase opacity class here
https://studio.backlight.dev/diff/4BeMe20hqOWTkdUL2NuJ/showcases?branch=pr:89@mveres