### PR TITLE
fix(speedy-links): links to different design systems

### DIFF
--- a/speedy-links/doc/speedy-links.md
+++ b/speedy-links/doc/speedy-links.md
@@ -172,10 +172,10 @@ setupSpeedyLinks({
 
 ## Rationale and sources of inspiration
 
-The inspiraton comes from [turbo](https://github.com/hotwired/turbo) (new library from the authors of [turbolinks](https://github.com/turbolinks/turbolinks/)) and [pjax](https://github.com/MoOx/pjax).
+The inspiration comes from [turbo](https://github.com/hotwired/turbo) (new library from the authors of [turbolinks](https://github.com/turbolinks/turbolinks/)) and [pjax](https://github.com/MoOx/pjax).
 These libraries might be better alternatives for static websites where all documents can be compiled to static HTML.
 
-Backlight is different here and therefore we needed smth similar, but more flexible and able to use dynamic JS code where static HTML is not sufficient, e.g. for interactive stories in Markdown files.
+Backlight is different here and therefore we needed something similar, but more flexible and able to use dynamic JS code where static HTML is not sufficient, e.g. for interactive stories in Markdown files.
 On top of that it has to support multiple technologies at the same time, often mixed up with each other in a single project.
 That's why we don't make any assumptions about how rendering is implemented, whether it's just static HTML string or JS code with dynamic variables, whether it can just be set as `innerHTML` or requires a framework or library to render.
 

--- a/speedy-links/src/speedy-links.ts
+++ b/speedy-links/src/speedy-links.ts
@@ -30,7 +30,7 @@ async function onClick(event: MouseEvent): Promise<void> {
     const url = link.href;
     const hash = new URL(url).hash;
 
-    if (isDifferentOriginUrl(url)) {
+    if (!isSameProjectURL(url)) {
       return;
     }
 
@@ -53,8 +53,16 @@ async function onPopState(): Promise<void> {
   await renderPage(location.href);
 }
 
-function isDifferentOriginUrl(url: string): boolean {
-  return new URL(url).origin !== location.origin;
+function isSameProjectURL(url: string): boolean {
+  const _url = new URL(url);
+  // Compare path prefixes, typically /doc/{projectId}
+  const currentRoot = location.pathname.slice(1).split('/');
+  const targetRoot = _url.pathname.slice(1).split('/');
+  return (
+    _url.origin === location.origin &&
+    currentRoot[0] === targetRoot[0] &&
+    currentRoot[1] === targetRoot[1]
+  );
 }
 
 function isSamePageUrl(url: string): boolean {


### PR DESCRIPTION
Previous implem was trying to speed-link links to different projects,
failing as it's not possible to load the module of another project
