### PR TITLE
feat(speedy-links): rename type

### DIFF
--- a/speedy-links/index.ts
+++ b/speedy-links/index.ts
@@ -1,2 +1,2 @@
-export type { ActivateLinksOptions } from './src/speedy-links';
+export type { SpeedyLinksOptions } from './src/speedy-links';
 export { setupSpeedyLinks } from './src/speedy-links';

--- a/speedy-links/src/speedy-links.ts
+++ b/speedy-links/src/speedy-links.ts
@@ -1,4 +1,4 @@
-export interface ActivateLinksOptions {
+export interface SpeedyLinksOptions {
   mapLinkUrlToModuleUrl: (
     url: string
   ) => string | undefined | Promise<string | undefined>;
@@ -7,11 +7,11 @@ export interface ActivateLinksOptions {
 }
 
 let hasBeenSetup = false;
-let opts: ActivateLinksOptions;
+let opts: SpeedyLinksOptions;
 let linkSelector: string;
 const modulesCache = {};
 
-export function setupSpeedyLinks(options: ActivateLinksOptions): void {
+export function setupSpeedyLinks(options: SpeedyLinksOptions): void {
   if (hasBeenSetup) {
     return;
   }


### PR DESCRIPTION
I forgot to rename this type when renaming the lib to `speedyLinks` before the release, time to fix that.