### PR TITLE
fix: move search to layout group

### DIFF
--- a/studio.config.json
+++ b/studio.config.json
@@ -5,8 +5,8 @@
       "introduction",
       ["Design Token Showcases", ["tailwind-showcases", "css-showcases"]],
       ["Components", ["do-dont", "note", "columns"]],
-      ["Layout", ["layout", "speedy-links"]],
-      ["Atoms", ["box", "clipboard", "text", "showcases", "space", "search"]],
+      ["Layout", ["layout", "speedy-links", "search"]],
+      ["Atoms", ["box", "clipboard", "text", "showcases", "space"]],
       ["Infra", ["doc-layout"]]
     ]
   }


### PR DESCRIPTION
Found this during my work on `dockit-version-selector`, I think the layout group will eventually be

```
["Layout", ["layout", "speedy-links", "search", "version-selector"]],
```

so moving `search` there too