### PR TITLE
feat(layout): improve support of different base formats

### DIFF
--- a/layout/src/Layout.ts
+++ b/layout/src/Layout.ts
@@ -235,7 +235,9 @@ export class Layout extends LitElement {
   }
 
   private getPageUrlWithoutOrigin(page: Page): string {
-    return (this.context?.base || '') + page.url;
+    const baseUrl = new URL(this.context?.base || '/', location.href);
+    const pageUrl = new URL(page.url, baseUrl);
+    return pageUrl.href.replace(location.origin, '');
   }
 
   private toggleColorScheme(): void {


### PR DESCRIPTION
When I worked on multiverse, I tried different base formats:
1. absolute pathname, e.g. "/docs/" (already supported)
2. absolute URL, e.g. "http://my-domain.dev/docs/" (broken, doesn't pass current page check)
3. relative, e.g. "../../" (broken, doesn't pass current page check)

This PR extends support for other options making 2 and 3 work too.